### PR TITLE
Added virial components as argument of the latte_lib

### DIFF
--- a/src/latte_c_bind.f90
+++ b/src/latte_c_bind.f90
@@ -23,54 +23,51 @@
 !! \param FLAGS Different control flags that can be passed to LATTE (not in use yet)
 !! \param NATS Number of atoms
 !! \param COORDS Coordinates. Example: y-coordinate of atom 1 = COORDS(2,1)
-!! \param TYPES An index for all the different atoms in the system. 
+!! \param TYPES An index for all the different atoms in the system.
 !! \param NTYPES Number of different elements in the system
-!! \param MASSES Element masses for every different element of the system. 
+!! \param MASSES Element masses for every different element of the system.
 !! \param XLO Lowest dimensions of the box
 !! \param XHI Highest dimensions of the box
 !! \param FORCES Forces for every atom as output.
-!! \param MAXITER Latte MAXITER keyword. If MAXITER = -1, only the Forces are computed. 
+!! \param MAXITER Latte MAXITER keyword. If MAXITER = -1, only the Forces are computed.
 !!        If MAXITER = 0, MAXITER is read from latte.in file.
 !!        IF MAXITER > 0, MAXITER is passed trough the library call.
 !! \param VENERG This is the potential Energy that is given back from latte to the hosting code.
 !! \param VEL Velocities passed to latte.
-!! \param DT integration step passed to latte. 
+!! \param DT integration step passed to latte.
 !!
-!! \brief This routine will be used load call latte_lib from a C/C++ program: 
+!! \brief This routine will be used load call latte_lib from a C/C++ program:
 !!
 !! \brief Note: To get the mass of atom 3 we do:
-!! \verbatim  
+!! \verbatim
 !!      MASS(TYPES(3))
 !! \endverbatim
 !!
 !! \brief Note: To get the lattice vectors as formated in LATTE we do:
-!! \verbatim  
+!! \verbatim
 !!      BOX(1,1) = XHI(1) - XLO(1); ...
 !! \endverbatim
 !!
 !! \brief Note: All units are LATTE units by default. See https://github.com/losalamos/LATTE/blob/master/Manual/LATTE_manual.pdf
 !!
 SUBROUTINE LATTE_C_BIND (FLAGS,NATS,COORDS,TYPES,NTYPES,MASSES,XLO &
-           ,XHI,FORCES, MAXITER, VENERG, VEL, DT) BIND (C, NAME="latte")
+           ,XHI,FORCES, MAXITER, VENERG, VEL, DT, VIRIALINOUT) BIND (C, NAME="latte")
 
   USE ISO_C_BINDING, ONLY: C_CHAR, C_NULL_CHAR, C_DOUBLE, C_INT
-  USE LATTE_LIB    
-   
+  USE LATTE_LIB
+
   IMPLICIT NONE
-  
+
   INTEGER(C_INT)                 ::  NATS, NTYPES, MAXITER
   INTEGER(C_INT)                 ::  TYPES(NATS), FLAGS(5)
   REAL(C_DOUBLE)                 ::  COORDS(3,NATS), MASSES(NTYPES), XHI(3)
   REAL(C_DOUBLE)                 ::  XLO(3), EKIN, VENERG, DT
-  REAL(C_DOUBLE), INTENT(INOUT)  ::  FORCES(3, NATS), VEL(3, NATS)   
+  REAL(C_DOUBLE), INTENT(INOUT)  ::  FORCES(3, NATS), VEL(3, NATS)
+  REAL(C_DOUBLE), INTENT(INOUT)  ::  VIRIALINOUT(6)
   INTEGER                        ::  I
-      
-  
-  CALL LATTE(NTYPES,TYPES,COORDS,MASSES,XLO,XHI,FORCES, MAXITER, VENERG, VEL, DT)
-  
-   
+
+  CALL LATTE(NTYPES,TYPES,COORDS,MASSES,XLO,XHI,FORCES, MAXITER, VENERG, VEL, DT, VIRIALINOUT)
+
   RETURN
-  
-END SUBROUTINE LATTE_C_BIND       
 
-
+END SUBROUTINE LATTE_C_BIND

--- a/src/latte_lib.f90
+++ b/src/latte_lib.f90
@@ -74,6 +74,7 @@ CONTAINS
   !! \param VENERG This is the potential Energy that is given back from latte to the hosting code.
   !! \param VEL Velocities passed to latte.
   !! \param DT integration step passed to latte.
+  !! \param VIRIALINOUT Components of the second virial coefficient
   !!
   !! \brief This routine will be used load call latte_lib from a C/C++ program:
   !!
@@ -90,7 +91,7 @@ CONTAINS
   !! \brief Note: All units are LATTE units by default. See https://github.com/losalamos/LATTE/blob/master/Manual/LATTE_manual.pdf
   !!
   SUBROUTINE LATTE(NTYPES,TYPES,CR_IN,MASSES_IN,XLO,XHI,FTOT_OUT, &
-                   MAXITER_IN, VENERG, VEL_IN, DT_IN)
+                   MAXITER_IN, VENERG, VEL_IN, DT_IN, VIRIALINOUT)
 
     IMPLICIT NONE
 
@@ -104,6 +105,7 @@ CONTAINS
     REAL(LATTEPREC), INTENT(IN) :: CR_IN(:,:),VEL_IN(:,:), MASSES_IN(:),XLO(3),XHI(3)
     REAL(LATTEPREC), INTENT(IN) :: DT_IN
     REAL(LATTEPREC), INTENT(OUT) :: FTOT_OUT(:,:), VENERG
+    REAL(LATTEPREC), INTENT(OUT) :: VIRIALINOUT(6)
     INTEGER, INTENT(IN) ::  NTYPES, TYPES(:), MAXITER_IN
 
 #ifdef PROGRESSON
@@ -533,7 +535,7 @@ CONTAINS
       ESPIN = ZERO
       IF (SPINON .EQ. 1) CALL GETSPINE
 
-      !CALL GETPRESSURE
+!      CALL GETPRESSURE
 
       IF (CONTROL .NE. 1 .AND. CONTROL .NE. 2 .AND. KBT .GT. 0.000001 ) THEN
 
@@ -555,6 +557,19 @@ CONTAINS
 
       FTOT_OUT = FTOT
 
+      IF (BASISTYPE .EQ. "NONORTHO") THEN
+
+        VIRIAL = VIRBOND + VIRPAIR + VIRCOUL
+
+         IF (SPINON .EQ. 0) THEN
+            VIRIAL = VIRIAL - VIRPUL + VIRSCOUL
+         ELSE
+            VIRIAL = VIRIAL - VIRPUL + VIRSCOUL + VIRSSPIN
+         ENDIF
+
+      ENDIF
+
+      VIRIALINOUT = -VIRIAL
 
       INITIALIZED = .true.
 


### PR DESCRIPTION
I added the VIRIAL array as an argument of the LATTE() subroutine. The pressures produced but both
lammps-latte and latte are the same. 