### PR TITLE
Allow checking for the ABI version from the C/C++ wrapper

### DIFF
--- a/src/latte_c_bind.f90
+++ b/src/latte_c_bind.f90
@@ -82,3 +82,20 @@ SUBROUTINE LATTE_C_BIND (FLAGS,NATS,COORDS,TYPES,NTYPES,MASSES,XLO &
   RETURN
 
 END SUBROUTINE LATTE_C_BIND
+
+!> Function for Latte-C++ interfacing.
+!! \return ABIVERSION integer representing the date of the last change
+!!          to the C/C++ interface (e.g. 20180221)
+!!
+!! \brief This function will be used prior to calling the LATTE library
+!!        to allow the calling code to ensure the linked library version is compatible.
+!!
+INTEGER(C_INT) FUNCTION LATTE_C_ABIVERSION()  BIND (C, NAME="latte_abiversion") 
+  USE ISO_C_BINDING, ONLY: C_INT
+
+  IMPLICIT NONE
+
+  LATTE_C_ABIVERSION = 20180207
+  RETURN
+
+END FUNCTION LATTE_C_ABIVERSION


### PR DESCRIPTION
Since the compiled object of the C/C++ wrapper does not contain any information about the calling sequence (aka ABI), C/C++ codes cannot determine whether the ABI is compatible at link time and might cause segmentation faults in case the interface was changed, but not adapted in the C/C++ code. The added function `latte_abiversion()` will return an integer representing the date of the last change to the ABI. Thus the calling code can do a test like the following:
```C
if (latte_abiversion() != 20180207) {
   fprintf(stderr,"Linked to an incompatible LATTE library version\n");
   exit(1);
}
```
This is particularly helpful, when LATTE would be compiled/linked as a shared library, where people might update the shared library without having to recompile the calling code.