### PR TITLE
Move ABI version constant into the Fortran library module of the code

### DIFF
--- a/src/latte_c_bind.f90
+++ b/src/latte_c_bind.f90
@@ -90,12 +90,12 @@ END SUBROUTINE LATTE_C_BIND
 !! \brief This function will be used prior to calling the LATTE library
 !!        to allow the calling code to ensure the linked library version is compatible.
 !!
-INTEGER(C_INT) FUNCTION LATTE_C_ABIVERSION()  BIND (C, NAME="latte_abiversion") 
+INTEGER(C_INT) FUNCTION LATTE_C_ABIVERSION()  BIND (C, NAME="latte_abiversion")
   USE ISO_C_BINDING, ONLY: C_INT
-
+  USE LATTE_LIB,     ONLY: LATTE_ABIVERSION
   IMPLICIT NONE
 
-  LATTE_C_ABIVERSION = 20180207
+  LATTE_C_ABIVERSION = LATTE_ABIVERSION
   RETURN
 
 END FUNCTION LATTE_C_ABIVERSION

--- a/src/latte_lib.f90
+++ b/src/latte_lib.f90
@@ -56,7 +56,13 @@ MODULE LATTE_LIB
 
   PRIVATE
 
-  PUBLIC :: LATTE
+  ! Defines the version of the binary interface.
+  ! Adjust if non-backward compatible changes are made to the interface.
+  ! Use in codes using the library interface to make certain a compatible
+  ! version of the LATTE library is used.
+  INTEGER, PARAMETER :: LATTE_ABIVERSION = 20180207
+
+  PUBLIC :: LATTE, LATTE_ABIVERSION
 
 CONTAINS
 


### PR DESCRIPTION
As remarked by @nicolasbock the ABI version constant can also be defined in the Fortran module in a similar fashion as implemented for the C interface in PR #24.
This pull request implements this and imports this constant into the C interface for consistency.