### PR TITLE
New output format for "make test"

### DIFF
--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -25,12 +25,13 @@ for name in single.point single.point.noelec single.point.rspace ; do
   cp  ./tests/$REF .
   cp  ./tests/$COORDS ./bl/inputblock.dat
 
-  echo -e "\nTesting for "$name" \n"
+  echo -en "   Testing for "$name" ... "
 
-  time $RUN > out
+  time=`( /usr/bin/time -f "%S" $RUN > out ) 2>&1 > /dev/null`
   ENERG=`grep -e "FREE ENERGY" out | awk 'NF>1{print $5}'`
   echo $ENERG > energy.out
 
+  echo -n "($time s) "
   python ./tests/test-energy.py --reference $REF --current energy.out --reltol 0.00001
 
   rm $REF out
@@ -52,10 +53,11 @@ for name in opt opt.cg opt_cons dorbitals; do
     cp ./tests/freeze.in .
   fi
 
-  echo -e "\nTesting for "$name" \n"
+  echo -en "   Testing for "$name" ... "
 
-  time $RUN > out
+  time=`( /usr/bin/time -f "%S" $RUN > out ) 2>&1 > /dev/null`
 
+  echo -n "($time s) "
   python ./tests/test-optim.py --reference $REF --current monitorrelax.xyz --reltol 0.00001
 
   #rm $REF monitorrelax.xyz out
@@ -74,12 +76,13 @@ for name in tableread 0scf 2scf fullscf fullscf.etemp sp2 sp2.sparse fullscf.nvt
   cp  ./tests/$REF .
   cp  ./tests/$COORDS ./bl/inputblock.dat
 
-  echo -e "\nTesting for "$name" \n"
+  echo -en "   Testing for "$name" ... "
 
-  time $RUN > out
+  time=`( /usr/bin/time -f "%S" $RUN > out ) 2>&1 > /dev/null`
+  
   grep "Data" out | sed 's/Data/ /g' | awk 'NF>1{print $2}' > energy.out
-  echo ""
 
+  echo -n "($time s) "
   python ./tests/test-energy.py --reference $REF --current energy.out --reltol 0.00001
 
   rm $REF energy.out out
@@ -98,9 +101,9 @@ for name in fittingoutput.dat ; do
   cp  ./tests/$REF .
   cp  ./tests/$COORDS ./bl/inputblock.dat
 
-  echo -e "\nTesting for "$name" \n"
+  echo -en "   Testing for "$name" ... "
 
-  time $RUN > out
+  time=`( /usr/bin/time -f "%S" $RUN > out ) 2>&1 > /dev/null`
   
   tol=0.0001
   
@@ -128,10 +131,12 @@ for name in fittingoutput.dat ; do
       }
     ' $REF`
   
+  echo -n "($time s) "
   if [ "$check" -eq 0 ]
   then
-    echo "Diff test passed without failure ..."
+    echo "PASSED"
   else
+    echo ""
     diff $REF $name
     exit -1
   fi
@@ -158,13 +163,14 @@ for name in 0scf fullscf sp2 ; do
   cp  ./tests/$REF .
   cp  ./tests/$COORDS ./bl/inputblock.dat
 
-  echo -e "\nTesting for "$name" \n"
+  echo -en "   Testing for "$name" ... "
 
-  time $RUN > out
+  time=`( /usr/bin/time -f "%S" $RUN > out ) 2>&1 > /dev/null`
+  
   grep "Data" out | sed 's/Data/ /g' | awk 'NF>1{print $2}' > energy.out
-  echo ""
-
   grep Energy out | sed -e s/"PAR"/$STRR/g  >  input_tmp.in
+  
+  echo -n "($time s) "
   python ./tests/test-energy.py --reference $REF --current energy.out --reltol 0.00001
 
   rm $REF energy.out input_tmp.in

--- a/tests/test-energy.py
+++ b/tests/test-energy.py
@@ -44,7 +44,7 @@ def compare_MD(reference, current, reltol):
         raise Exception(("[error] when comparing '%s' with '%s'" % (reference, current))
                         + "energies do not agree")
 
-    print("Energy test passed without failure ...")  
+    print("PASSED") 
 
 def main():
     """The main function.

--- a/tests/test-optim.py
+++ b/tests/test-optim.py
@@ -70,7 +70,7 @@ def compare_coordinates(reference, current, reltol):
         raise Exception(("[error] when comparing '%s' with '%s'" % (reference, current))
                         + "structures do not agree")
         
-    print("optim test passed without failure ...")  
+    print("PASSED")
 
 def main():
     """The main function.


### PR DESCRIPTION
Now the output looks like this:

Testing LATTE with new (latte.in) input files 

   Testing for single.point ... (0.67 s) PASSED
   Testing for single.point.noelec ... (2.61 s) PASSED
   Testing for single.point.rspace ... (2.64 s) PASSED
   Testing for opt ... (26.74 s) PASSED
   Testing for opt.cg ... (32.29 s) PASSED
   Testing for opt_cons ... (35.95 s) PASSED
   Testing for dorbitals ... (37.62 s) PASSED
   Testing for tableread ... (1.04 s) PASSED
   Testing for 0scf ... (8.21 s) PASSED
   Testing for 2scf ... (8.57 s) PASSED
   Testing for fullscf ... (11.02 s) PASSED
   Testing for fullscf.etemp ... (11.54 s) PASSED
   Testing for sp2 ... (3.26 s) PASSED
   Testing for sp2.sparse ... (2.78 s) PASSED
   Testing for fullscf.nvt ... (16.72 s) PASSED
   Testing for fullscf.npt ... (12.83 s) PASSED
   Testing for fullscf.vdw ... (14.46 s) PASSED
   Testing for fullscf.spin ... (10.58 s) PASSED
   Testing for fullscf.kon ... (66.70 s) PASSED
   Testing for fullscf.rspace ... (0.87 s) PASSED
   Testing for fittingoutput.dat ... (0.58 s) PASSED

Testing LATTE with original input files 

   Testing for 0scf ... (8.22 s) PASSED
   Testing for fullscf ... (12.91 s) PASSED
   Testing for sp2 ... (2.70 s) PASSED
