### PR TITLE
Performance test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ env:
   - OPTIONS="CVR=ON MAKELIB=ON lammps" TEST="_lmp" CHOICES=gfort.lapack
   - LATTE_CMAKE=yes CMAKE_WITH_PROGRESS=yes
   - LATTE_CMAKE=yes LAMMPS_CMAKE=yes
+  - LATTE_PERFORMANCE=yes
 
 script:
   -  cp -f -v ./makefiles/makefile.CHOICES.${CHOICES:-gfort.lapack} makefile.CHOICES

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ env:
   - LATTE_CMAKE=yes CMAKE_WITH_PROGRESS=yes
   - LATTE_CMAKE=yes LAMMPS_CMAKE=yes
   - LATTE_PERFORMANCE=yes TEST="_lmp" CHOICES=gfort.lapack
-  - LATTE_PERFORMANCE=yes OPTIONS="CVR=ON PROGRESS=ON" TEST="_lmp" CHOICES=gfort.lapack
+  - LATTE_PERFORMANCE=yes OPTIONS="CVR=ON PROGRESS=ON" TEST="" CHOICES=gfort.lapack
 
 script:
   -  cp -f -v ./makefiles/makefile.CHOICES.${CHOICES:-gfort.lapack} makefile.CHOICES

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,8 @@ env:
   - OPTIONS="CVR=ON MAKELIB=ON lammps" TEST="_lmp" CHOICES=gfort.lapack
   - LATTE_CMAKE=yes CMAKE_WITH_PROGRESS=yes
   - LATTE_CMAKE=yes LAMMPS_CMAKE=yes
-  - LATTE_PERFORMANCE=yes TEST="_lmp" CHOICES=gfort.lapack
-  - LATTE_PERFORMANCE=yes OPTIONS="CVR=ON PROGRESS=ON" TEST="" CHOICES=gfort.lapack
+  - LATTE_PERFORMANCE=yes TEST="" CHOICES=gfort.lapack
+#  - LATTE_PERFORMANCE=yes OPTIONS="CVR=ON PROGRESS=ON" TEST="" CHOICES=gfort.lapack
 
 script:
   -  cp -f -v ./makefiles/makefile.CHOICES.${CHOICES:-gfort.lapack} makefile.CHOICES

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,8 @@ env:
   - OPTIONS="CVR=ON MAKELIB=ON lammps" TEST="_lmp" CHOICES=gfort.lapack
   - LATTE_CMAKE=yes CMAKE_WITH_PROGRESS=yes
   - LATTE_CMAKE=yes LAMMPS_CMAKE=yes
-  - LATTE_PERFORMANCE=yes
+  - LATTE_PERFORMANCE=yes TEST="_lmp" CHOICES=gfort.lapack
+  - LATTE_PERFORMANCE=yes OPTIONS="CVR=ON PROGRESS=ON" TEST="_lmp" CHOICES=gfort.lapack
 
 script:
   -  cp -f -v ./makefiles/makefile.CHOICES.${CHOICES:-gfort.lapack} makefile.CHOICES

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,7 @@
+include ../makefile.CHOICES
+
+PPFLAGS = -DXSYEVD -D$(PRECISION)PREC -DGPU$(GPUOPT) -DDBCSR_$(DBCSR_OPT) -DMPI_$(MPIOPT)
+
+all:
+# 	$(FC) $(FFLAGS) $(PPFLAGS) timer_cpu_time.f90 -o timer_cpu_time
+	$(FC) timer_cpu_time.f90 -o timer_cpu_time

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -78,7 +78,7 @@ for name in single.point single.point.noelec single.point.rspace ; do
   
   if [ "$LATTE_PERFORMANCE" = "yes" ]
   then
-	test=`echo "sqrt($relativeTime-${performanceExpectedTimes[$name]})^2/${performanceExpectedTimes[$name]} < 0.1" | bc -l`
+	test=`echo "($relativeTime-${performanceExpectedTimes[$name]})/${performanceExpectedTimes[$name]} < 0.1" | bc -l`
 	[ "$test" -eq 0 ] && exit -1
   fi
 
@@ -111,7 +111,7 @@ for name in opt opt.cg opt_cons dorbitals; do
   
   if [ "$LATTE_PERFORMANCE" = "yes" ]
   then
-	test=`echo "sqrt($relativeTime-${performanceExpectedTimes[$name]})^2/${performanceExpectedTimes[$name]} < 0.1" | bc -l`
+	test=`echo "($relativeTime-${performanceExpectedTimes[$name]})/${performanceExpectedTimes[$name]} < 0.1" | bc -l`
 	[ "$test" -eq 0 ] && exit -1
   fi
 
@@ -143,7 +143,7 @@ for name in tableread 0scf 2scf fullscf fullscf.etemp sp2 sp2.sparse fullscf.nvt
 
   if [ "$LATTE_PERFORMANCE" = "yes" ]
   then
-	test=`echo "sqrt($relativeTime-${performanceExpectedTimes[$name]})^2/${performanceExpectedTimes[$name]} < 0.1" | bc -l`
+	test=`echo "($relativeTime-${performanceExpectedTimes[$name]})/${performanceExpectedTimes[$name]} < 0.1" | bc -l`
 	[ "$test" -eq 0 ] && exit -1
   fi
   
@@ -206,7 +206,7 @@ for name in fittingoutput.dat ; do
   
   if [ "$LATTE_PERFORMANCE" = "yes" ]
   then
-	test=`echo "sqrt($relativeTime-${performanceExpectedTimes[$name]})^2/${performanceExpectedTimes[$name]} < 0.1" | bc -l`
+	test=`echo "($relativeTime-${performanceExpectedTimes[$name]})/${performanceExpectedTimes[$name]} < 0.1" | bc -l`
 	[ "$test" -eq 0 ] && exit -1
   fi
 
@@ -248,7 +248,7 @@ for name in 0scf fullscf sp2 ; do
   
   if [ "$LATTE_PERFORMANCE" = "yes" ]
   then
-	test=`echo "sqrt($relativeTime-${performanceExpectedTimes[$name]})^2/${performanceExpectedTimes[$name]} < 0.1" | bc -l`
+	test=`echo "($relativeTime-${performanceExpectedTimes[$name]})/${performanceExpectedTimes[$name]} < 0.1" | bc -l`
 	[ "$test" -eq 0 ] && exit -1
   fi
 

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -14,7 +14,7 @@ echo ""
 ( cd tests; make; cd .. ) &> /dev/null
 
 echo -en "   Testing for reference ... "
-timeRef=`( /usr/bin/time -f "%S" ./tests/timer_cpu_time > out ) 2>&1 > /dev/null`
+timeRef=`( /usr/bin/time -f "%U" ./tests/timer_cpu_time > out ) 2>&1 > /dev/null`
 
 relativeTime=`echo "$timeRef/$timeRef" | bc -l | awk '{printf("%.3f",$1)}'`
 echo "(${timeRef}s,$relativeTime) PASSED"
@@ -42,7 +42,7 @@ for name in single.point single.point.noelec single.point.rspace ; do
 
   echo -en "   Testing for "$name" ... "
 
-  time=`( /usr/bin/time -f "%S" $RUN > out ) 2>&1 > /dev/null`
+  time=`( /usr/bin/time -f "%U" $RUN > out ) 2>&1 > /dev/null`
   ENERG=`grep -e "FREE ENERGY" out | awk 'NF>1{print $5}'`
   echo $ENERG > energy.out
 
@@ -71,7 +71,7 @@ for name in opt opt.cg opt_cons dorbitals; do
 
   echo -en "   Testing for "$name" ... "
 
-  time=`( /usr/bin/time -f "%S" $RUN > out ) 2>&1 > /dev/null`
+  time=`( /usr/bin/time -f "%U" $RUN > out ) 2>&1 > /dev/null`
 
   relativeTime=`echo "$time/$timeRef" | bc -l | awk '{printf("%.3f",$1)}'`
   echo -n "(${time}s,$relativeTime) "
@@ -95,7 +95,7 @@ for name in tableread 0scf 2scf fullscf fullscf.etemp sp2 sp2.sparse fullscf.nvt
 
   echo -en "   Testing for "$name" ... "
 
-  time=`( /usr/bin/time -f "%S" $RUN > out ) 2>&1 > /dev/null`
+  time=`( /usr/bin/time -f "%U" $RUN > out ) 2>&1 > /dev/null`
   
   grep "Data" out | sed 's/Data/ /g' | awk 'NF>1{print $2}' > energy.out
 
@@ -121,7 +121,7 @@ for name in fittingoutput.dat ; do
 
   echo -en "   Testing for "$name" ... "
 
-  time=`( /usr/bin/time -f "%S" $RUN > out ) 2>&1 > /dev/null`
+  time=`( /usr/bin/time -f "%U" $RUN > out ) 2>&1 > /dev/null`
   
   tol=0.0001
   
@@ -187,7 +187,7 @@ for name in 0scf fullscf sp2 ; do
 
   echo -en "   Testing for "$name" ... "
 
-  time=`( /usr/bin/time -f "%S" $RUN > out ) 2>&1 > /dev/null`
+  time=`( /usr/bin/time -f "%U" $RUN > out ) 2>&1 > /dev/null`
   
   grep "Data" out | sed 's/Data/ /g' | awk 'NF>1{print $2}' > energy.out
   grep Energy out | sed -e s/"PAR"/$STRR/g  >  input_tmp.in

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -45,6 +45,11 @@ timeRef=`( /usr/bin/time -f "%U" ./tests/timer_cpu_time > out ) 2>&1 > /dev/null
 relativeTime=`echo "$timeRef/$timeRef" | bc -l | awk '{printf("%.3f",$1)}'`
 echo "(${timeRef}s,$relativeTime) PASSED"
 
+if [ "$LATTE_PERFORMANCE" = "yes" ]
+then
+	echo ">> If performance goes lower than 10% the test will fail"
+fi
+
 echo ""
 echo "Testing LATTE with new (latte.in) input files"
 echo "============================================="

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -4,6 +4,32 @@
 
 MY_PATH=`pwd`                                   # Capturing the local path of the folder where we are running.
 
+declare -A performanceExpectedTimes
+performanceExpectedTimes["single.point"]=0.014
+performanceExpectedTimes["single.point.noelec"]=0.027
+performanceExpectedTimes["single.point.rspace"]=0.036
+performanceExpectedTimes["opt"]=0.127
+performanceExpectedTimes["opt.cg"]=0.129
+performanceExpectedTimes["opt_cons"]=0.127
+performanceExpectedTimes["dorbitals"]=0.412
+performanceExpectedTimes["tableread"]=1.700
+performanceExpectedTimes["0scf"]=0.127
+performanceExpectedTimes["2scf"]=0.120
+performanceExpectedTimes["fullscf"]=0.158
+performanceExpectedTimes["fullscf.etemp"]=0.160
+performanceExpectedTimes["sp2"]=0.161
+performanceExpectedTimes["sp2.sparse"]=0.579
+performanceExpectedTimes["fullscf.nvt"]=0.158
+performanceExpectedTimes["fullscf.npt"]=0.157
+performanceExpectedTimes["fullscf.vdw"]=0.158
+performanceExpectedTimes["fullscf.spin"]=0.231
+performanceExpectedTimes["fullscf.kon"]=0.973
+performanceExpectedTimes["fullscf.rspace"]=0.014
+performanceExpectedTimes["fittingoutput.dat"]=0.002
+performanceExpectedTimes["0scf"]=0.127
+performanceExpectedTimes["fullscf"]=0.158
+performanceExpectedTimes["sp2"]=0.161
+
 RUN="./LATTE_DOUBLE"  # LATTE program executable
 
 echo ""
@@ -49,6 +75,12 @@ for name in single.point single.point.noelec single.point.rspace ; do
   relativeTime=`echo "$time/$timeRef" | bc -l | awk '{printf("%.3f",$1)}'`
   echo -n "(${time}s,$relativeTime) "
   python ./tests/test-energy.py --reference $REF --current energy.out --reltol 0.00001
+  
+  if [ "$LATTE_PERFORMANCE" = "yes" ]
+  then
+	test=`echo "sqrt($relativeTime-${performanceExpectedTimes[$name]})^2/${performanceExpectedTimes[$name]} < 0.1" | bc -l`
+	[ "$test" -eq 0 ] && exit -1
+  fi
 
   rm $REF out
 
@@ -76,6 +108,12 @@ for name in opt opt.cg opt_cons dorbitals; do
   relativeTime=`echo "$time/$timeRef" | bc -l | awk '{printf("%.3f",$1)}'`
   echo -n "(${time}s,$relativeTime) "
   python ./tests/test-optim.py --reference $REF --current monitorrelax.xyz --reltol 0.00001
+  
+  if [ "$LATTE_PERFORMANCE" = "yes" ]
+  then
+	test=`echo "sqrt($relativeTime-${performanceExpectedTimes[$name]})^2/${performanceExpectedTimes[$name]} < 0.1" | bc -l`
+	[ "$test" -eq 0 ] && exit -1
+  fi
 
   #rm $REF monitorrelax.xyz out
 done
@@ -103,6 +141,12 @@ for name in tableread 0scf 2scf fullscf fullscf.etemp sp2 sp2.sparse fullscf.nvt
   echo -n "(${time}s,$relativeTime) "
   python ./tests/test-energy.py --reference $REF --current energy.out --reltol 0.00001
 
+  if [ "$LATTE_PERFORMANCE" = "yes" ]
+  then
+	test=`echo "sqrt($relativeTime-${performanceExpectedTimes[$name]})^2/${performanceExpectedTimes[$name]} < 0.1" | bc -l`
+	[ "$test" -eq 0 ] && exit -1
+  fi
+  
   rm $REF energy.out out
 
 done
@@ -159,6 +203,12 @@ for name in fittingoutput.dat ; do
     diff $REF $name
     exit -1
   fi
+  
+  if [ "$LATTE_PERFORMANCE" = "yes" ]
+  then
+	test=`echo "sqrt($relativeTime-${performanceExpectedTimes[$name]})^2/${performanceExpectedTimes[$name]} < 0.1" | bc -l`
+	[ "$test" -eq 0 ] && exit -1
+  fi
 
   rm $REF out
 
@@ -195,6 +245,12 @@ for name in 0scf fullscf sp2 ; do
   relativeTime=`echo "$time/$timeRef" | bc -l | awk '{printf("%.3f",$1)}'`
   echo -n "(${time}s,$relativeTime) "
   python ./tests/test-energy.py --reference $REF --current energy.out --reltol 0.00001
+  
+  if [ "$LATTE_PERFORMANCE" = "yes" ]
+  then
+	test=`echo "sqrt($relativeTime-${performanceExpectedTimes[$name]})^2/${performanceExpectedTimes[$name]} < 0.1" | bc -l`
+	[ "$test" -eq 0 ] && exit -1
+  fi
 
   rm $REF energy.out input_tmp.in
 

--- a/tests/timer_cpu_time.f90
+++ b/tests/timer_cpu_time.f90
@@ -1,0 +1,667 @@
+program main
+
+!*****************************************************************************80
+!
+!! MAIN is the main program for TIMER_CPU_TIME.
+!
+!  Discussion:
+!
+!    TIMER_CPU_TIME uses CPU_TIME as the timer.
+!
+!  Licensing:
+!
+!    This code is distributed under the GNU LGPL license.
+!
+!  Modified:
+!
+!    06 February 2007
+!
+!  Author:
+!
+!    John Burkardt
+!
+  implicit none
+
+  call timestamp ( )
+
+  write ( *, '(a)' ) ' '
+  write ( *, '(a)' ) 'TIMER_CPU_TIME'
+  write ( *, '(a)' ) '  FORTRAN90 version.'
+  write ( *, '(a)' ) '  Demonstrate the use of the CPU_TIME timer.'
+  write ( *, '(a)' ) ' '
+  write ( *, '(a)' ) '  CPU_TIME is a FORTRAN 95 built in routine.'
+  write ( *, '(a)' ) ' '
+  write ( *, '(a)' ) '    call cpu_time ( reading )'
+
+  call test01 ( )
+  call test02 ( )
+  call test03 ( )
+  call test04 ( )
+  call test05 ( )
+!
+!  Terminate.
+!
+  write ( *, '(a)' ) ' '
+  write ( *, '(a)' ) 'TIMER_CPU_TIME'
+  write ( *, '(a)' ) '  Normal end of execution.'
+
+  write ( *, '(a)' ) ' '
+  call timestamp ( )
+
+  stop
+end
+subroutine test01 ( )
+
+!*****************************************************************************80
+!
+!! TEST01 times the FORTRAN90 RANDOM_NUMBER routine.
+!
+!  Licensing:
+!
+!    This code is distributed under the GNU LGPL license.
+!
+!  Modified:
+!
+!    20 May 2009
+!
+!  Author:
+!
+!    John Burkardt
+!
+  implicit none
+
+  integer ( kind = 4 ), parameter :: n_log_min = 0
+  integer ( kind = 4 ), parameter :: n_log_max = 20
+  integer ( kind = 4 ), parameter :: n_min = 2**n_log_min
+  integer ( kind = 4 ), parameter :: n_max = 2**n_log_max
+  integer ( kind = 4 ), parameter :: rep_num = 5
+
+  real ( kind = 8 ) delta(n_log_min:n_log_max,rep_num+3)
+  integer ( kind = 4 ) n
+  integer ( kind = 4 ) n_log
+  integer ( kind = 4 ) rep
+  real ( kind = 8 ) time1
+  real ( kind = 8 ) time2
+  real ( kind = 8 ) x(n_max)
+
+  write ( *, '(a)' ) ' '
+  write ( *, '(a)' ) 'TEST01'
+  write ( *, '(a)' ) '  Time the FORTRAN90 RANDOM_NUMBER routine:'
+  write ( *, '(a)' ) ' '
+  write ( *, '(a)' ) '    call random_number ( x(1:n) )'
+  write ( *, '(a)' ) ' '
+  write ( *, '(a,i12)' ) '  Data vectors will be of minimum size ', n_min
+  write ( *, '(a,i12)' ) '  Data vectors will be of maximum size ', n_max
+  write ( *, '(a,i12)' ) '  Number of repetitions of the operation: ', rep_num
+
+  do n_log = n_log_min, n_log_max
+
+    do rep = 1, rep_num
+
+      n = 2**( n_log )
+
+      call cpu_time ( time1 )
+
+      call random_number ( harvest = x(1:n) )
+
+      call cpu_time ( time2 )
+
+      delta(n_log,rep) = time2 - time1
+
+    end do
+
+    delta(n_log,rep_num+1) = minval ( delta(n_log,1:rep_num) )
+    delta(n_log,rep_num+2) = sum    ( delta(n_log,1:rep_num) ) &
+      / real ( rep_num, kind = 8 )
+    delta(n_log,rep_num+3) = maxval ( delta(n_log,1:rep_num) )
+
+  end do
+
+  write ( *, '(a)' ) ' '
+  write ( *, '(a)' ) '  Timing results:'
+  write ( *, '(a)' ) ' '
+  write ( *, '(a)' ) '    Vector Size  Rep #1        Rep #2        Rep #3        ' &
+    // 'Rep #4        Rep #5           Min           Ave           Max'
+  write ( *, '(a)' ) ' '
+  do n_log = n_log_min, n_log_max
+    n = 2**( n_log )
+    write ( *, '(i10,8f14.6)' ) n, delta(n_log,1:rep_num+3)
+  end do
+
+  return
+end
+subroutine test02 ( )
+
+!*****************************************************************************80
+!
+!! TEST02 times the vectorized EXP routine.
+!
+!  Licensing:
+!
+!    This code is distributed under the GNU LGPL license.
+!
+!  Modified:
+!
+!    06 February 2007
+!
+!  Author:
+!
+!    John Burkardt
+!
+  implicit none
+
+  integer ( kind = 4 ), parameter :: n_log_min = 12
+  integer ( kind = 4 ), parameter :: n_log_max = 22
+  integer ( kind = 4 ), parameter :: n_min = 2**n_log_min
+  integer ( kind = 4 ), parameter :: n_max = 2**n_log_max
+  integer ( kind = 4 ), parameter :: n_rep = 5
+
+  real ( kind = 8 ) delta(n_log_max,n_rep)
+  integer ( kind = 4 ) func
+  integer ( kind = 4 ) i_rep
+  integer ( kind = 4 ) n
+  integer ( kind = 4 ) n_log
+  real ( kind = 8 ), parameter :: pi = 3.141592653589793D+00
+  real ( kind = 8 ) time1
+  real ( kind = 8 ) time2
+  real ( kind = 8 ) x(n_max)
+  real ( kind = 8 ) y(n_max)
+
+  write ( *, '(a)' ) ' '
+  write ( *, '(a)' ) 'TEST02'
+  write ( *, '(a)' ) '  Time vectorized operations:'
+  write ( *, '(a)' ) ' '
+  write ( *, '(a)' ) '    y(1:n) =        x(1:n)  '
+  write ( *, '(a)' ) '    y(1:n) = PI *   x(1:n)  '
+  write ( *, '(a)' ) '    y(1:n) = sqrt ( x(1:n) )'
+  write ( *, '(a)' ) '    y(1:n) = exp  ( x(1:n) )'
+  write ( *, '(a)' ) ' '
+  write ( *, '(a,i12)' ) '  Data vectors will be of minimum size ', n_min
+  write ( *, '(a,i12)' ) '  Data vectors will be of maximum size ', n_max
+  write ( *, '(a,i12)' ) '  Number of repetitions of the operation: ', n_rep
+
+  do func = 1, 4
+
+    do i_rep = 1, n_rep
+
+      do n_log = n_log_min, n_log_max
+
+        n = 2**( n_log )
+
+        call random_number ( harvest = x(1:n) )
+
+        call cpu_time ( time1 )
+
+        if ( func == 1 ) then
+          y(1:n) = x(1:n)
+        else if ( func == 2 ) then
+          y(1:n) = pi * x(1:n)
+        else if ( func == 3 ) then
+          y(1:n) = sqrt ( x(1:n) )
+        else if ( func == 4 ) then
+          y(1:n) = exp ( x(1:n) )
+        end if
+
+        call cpu_time ( time2 )
+
+        delta(n_log,i_rep) = time2 - time1
+
+      end do
+
+    end do
+
+    write ( *, '(a)' ) ' '
+    write ( *, '(a)' ) '  Timing Results:'
+    write ( *, '(a)' ) ' '
+    write ( *, '(a)' ) '    Vector Size  Rep #1        Rep #2        ' &
+      //  'Rep #3        Rep #4        Rep #5'
+    write ( *, '(a)' ) ' '
+    do n_log = n_log_min, n_log_max
+      n = 2**( n_log )
+      write ( *, '(i10,5f14.6)' ) n, delta(n_log,1:n_rep)
+    end do
+
+  end do
+
+  return
+end
+subroutine test03 ( )
+
+!*****************************************************************************80
+!
+!! TEST03 times the unvectorized EXP routine.
+!
+!  Licensing:
+!
+!    This code is distributed under the GNU LGPL license.
+!
+!  Modified:
+!
+!    06 February 2007
+!
+!  Author:
+!
+!    John Burkardt
+!
+  implicit none
+
+  integer ( kind = 4 ), parameter :: n_log_min = 12
+  integer ( kind = 4 ), parameter :: n_log_max = 22
+  integer ( kind = 4 ), parameter :: n_min = 2**n_log_min
+  integer ( kind = 4 ), parameter :: n_max = 2**n_log_max
+  integer ( kind = 4 ), parameter :: n_rep = 5
+
+  real ( kind = 8 ) delta(n_log_max,n_rep)
+  integer ( kind = 4 ) func
+  integer ( kind = 4 ) i
+  integer ( kind = 4 ) i_rep
+  integer ( kind = 4 ) n
+  integer ( kind = 4 ) n_log
+  real ( kind = 8 ), parameter :: pi = 3.141592653589793D+00
+  real ( kind = 8 ) time1
+  real ( kind = 8 ) time2
+  real ( kind = 8 ) x(n_max)
+  real ( kind = 8 ) y(n_max)
+
+  write ( *, '(a)' ) ' '
+  write ( *, '(a)' ) 'TEST03'
+  write ( *, '(a)' ) '  Time the unvectorized loops:'
+  write ( *, '(a)' ) ' '
+  write ( *, '(a)' ) '    do i = 1, n'
+  write ( *, '(a)' ) '      y(i) =        x(i)  '
+  write ( *, '(a)' ) '      y(i) = PI *   x(i)  '
+  write ( *, '(a)' ) '      y(i) = sqrt ( x(i) )'
+  write ( *, '(a)' ) '      y(i) = exp  ( x(i) )'
+  write ( *, '(a)' ) '    end do'
+  write ( *, '(a)' ) ' '
+  write ( *, '(a,i12)' ) '  Data vectors will be of minimum size ', n_min
+  write ( *, '(a,i12)' ) '  Data vectors will be of maximum size ', n_max
+  write ( *, '(a,i12)' ) '  Number of repetitions of the operation: ', n_rep
+
+  do func = 1, 4
+
+    do i_rep = 1, n_rep
+
+      do n_log = n_log_min, n_log_max
+
+        n = 2**( n_log )
+
+        call random_number ( harvest = x(1:n) )
+
+        call cpu_time ( time1 )
+
+        if ( func == 1 ) then
+          do i = 1, n
+            y(i) = x(i)
+          end do
+        else if ( func == 2 ) then
+          do i = 1, n
+            y(i) = pi * x(i)
+          end do
+        else if ( func == 3 ) then
+          do i = 1, n
+            y(i) = sqrt ( x(i) )
+          end do
+        else if ( func == 4 ) then
+          do i = 1, n
+            y(i) = exp ( x(i) )
+          end do
+        end if
+
+        call cpu_time ( time2 )
+
+        delta(n_log,i_rep) = time2 - time1
+
+      end do
+
+    end do
+
+    write ( *, '(a)' ) ' '
+    write ( *, '(a)' ) '  Timing Results:'
+    write ( *, '(a)' ) ' '
+    write ( *, '(a)' ) '    Vector Size  Rep #1        Rep #2        ' &
+      //  'Rep #3        Rep #4        Rep #5'
+    write ( *, '(a)' ) ' '
+    do n_log = n_log_min, n_log_max
+      n = 2**( n_log )
+      write ( *, '(i10,5f14.6)' ) n, delta(n_log,1:n_rep)
+    end do
+
+  end do
+
+  return
+end
+subroutine test04 ( )
+
+!*****************************************************************************80
+!
+!! TEST04 times the 2D nearest neighbor problem.
+!
+!  Licensing:
+!
+!    This code is distributed under the GNU LGPL license.
+!
+!  Modified:
+!
+!    06 February 2007
+!
+!  Author:
+!
+!    John Burkardt
+!
+  implicit none
+
+  integer ( kind = 4 ), parameter :: n_log_min = 10
+  integer ( kind = 4 ), parameter :: n_log_max = 20
+  integer ( kind = 4 ), parameter :: n_min = 2**n_log_min
+  integer ( kind = 4 ), parameter :: n_max = 2**n_log_max
+  integer ( kind = 4 ), parameter :: n_rep = 5
+
+  real ( kind = 8 ) delta(n_log_max,n_rep)
+  real ( kind = 8 ) dist_i
+  real ( kind = 8 ) dist_min
+  integer ( kind = 4 ) i
+  integer ( kind = 4 ) i_min
+  integer ( kind = 4 ) i_rep
+  integer ( kind = 4 ) n
+  integer ( kind = 4 ) n_log
+  real ( kind = 8 ) time1
+  real ( kind = 8 ) time2
+  real ( kind = 8 ) x(2,n_max)
+  real ( kind = 8 ) y(2)
+
+  write ( *, '(a)' ) ' '
+  write ( *, '(a)' ) 'TEST04'
+  write ( *, '(a)' ) '  Time the 2D nearest neighbor problem.'
+  write ( *, '(a)' ) ' '
+  write ( *, '(a)' ) '  Given X(2,N) and Y(2),'
+  write ( *, '(a)' ) '    find X(2,*) closest to Y(2).'
+  write ( *, '(a)' ) ' '
+  write ( *, '(a)' ) '    do i = 1, n'
+  write ( *, '(a)' ) '      if distance ( x(2,i), y ) < minimum so far'
+  write ( *, '(a)' ) '        x_min = x(2,i)'
+  write ( *, '(a)' ) '    end do'
+  write ( *, '(a)' ) ' '
+  write ( *, '(a,i12)' ) '  Data vectors will be of minimum size ', n_min
+  write ( *, '(a,i12)' ) '  Data vectors will be of maximum size ', n_max
+  write ( *, '(a,i12)' ) '  Number of repetitions of the operation: ', n_rep
+
+  call random_number ( harvest = x(1:2,1:n_max) )
+  call random_number ( harvest = y(1:2) )
+
+  do i_rep = 1, n_rep
+
+    do n_log = n_log_min, n_log_max
+
+      n = 2**( n_log )
+
+      call cpu_time ( time1 )
+
+      dist_min = huge ( dist_min )
+      i_min = 0
+      do i = 1, n
+        dist_i = sum ( ( x(1:2,i) - y(1:2) )**2 )
+        if ( dist_i < dist_min ) then
+          dist_min = dist_i
+          i_min = i
+        end if
+      end do
+
+      call cpu_time ( time2 )
+
+      delta(n_log,i_rep) = time2 - time1
+
+    end do
+
+  end do
+
+  write ( *, '(a)' ) ' '
+  write ( *, '(a)' ) '  Timing Results:'
+  write ( *, '(a)' ) ' '
+  write ( *, '(a)' ) '    Vector Size  Rep #1        Rep #2        Rep #3        ' &
+    // 'Rep #4        Rep #5'
+  write ( *, '(a)' ) ' '
+  do n_log = n_log_min, n_log_max
+    n = 2**( n_log )
+    write ( *, '(i10,5f14.6)' ) n, delta(n_log,1:n_rep)
+  end do
+
+  return
+end
+subroutine test05 ( )
+
+!*****************************************************************************80
+!
+!! TEST05 times the matrix multiplication problem problem.
+!
+!  Licensing:
+!
+!    This code is distributed under the GNU LGPL license.
+!
+!  Modified:
+!
+!    05 March 2008
+!
+!  Author:
+!
+!    John Burkardt
+!
+  implicit none
+
+  integer ( kind = 4 ), parameter :: l_log_min = 1
+  integer ( kind = 4 ), parameter :: l_log_max = 5
+  integer ( kind = 4 ), parameter :: l_min = 4**l_log_min
+  integer ( kind = 4 ), parameter :: l_max = 4**l_log_max
+  integer ( kind = 4 ), parameter :: rep_num = 5
+
+  real ( kind = 8 ), allocatable, dimension ( :, : ) :: a
+  real ( kind = 8 ), allocatable, dimension ( :, : ) :: b
+  real ( kind = 8 ), allocatable, dimension ( :, : ) :: c
+  real ( kind = 8 ) delta(l_log_min:l_log_max,rep_num)
+  integer ( kind = 4 ) i
+  integer ( kind = 4 ) j
+  integer ( kind = 4 ) k
+  integer ( kind = 4 ) l
+  integer ( kind = 4 ) l_log
+  integer ( kind = 4 ) m
+  integer ( kind = 4 ) n
+  integer ( kind = 4 ) rep
+  real ( kind = 8 ) time1
+  real ( kind = 8 ) time2
+
+  write ( *, '(a)' ) ' '
+  write ( *, '(a)' ) 'TEST05'
+  write ( *, '(a)' ) '  Time the matrix multiplication problem.'
+  write ( *, '(a)' ) ' '
+  write ( *, '(a)' ) '  Compute C = A * B'
+  write ( *, '(a)' ) ' '
+  write ( *, '(a)' ) '  where'
+  write ( *, '(a)' ) '    A is an L by M matrix,'
+  write ( *, '(a)' ) '    B is an M by N matrix,'
+  write ( *, '(a)' ) '  and so'
+  write ( *, '(a)' ) '    C is an L by N matrix.'
+  write ( *, '(a)' ) ' '
+  write ( *, '(a,i12)' ) '  Minimum value of L = M = N = ', l_min
+  write ( *, '(a,i12)' ) '  Maximum value of L = M = N = ', l_max
+  write ( *, '(a,i12)' ) '  Number of repetitions of the operation: ', rep_num
+
+  write ( *, '(a)' ) ' '
+  write ( *, '(a)' ) '  Use nested DO loops for matrix multiplication.'
+
+  do rep = 1, rep_num
+
+    do l_log = l_log_min, l_log_max - 1
+
+      l = 4**( l_log )
+      m = l
+      n = l
+
+      allocate ( a(1:l,1:l) )
+      allocate ( b(1:l,1:l) )
+      allocate ( c(1:l,1:l) )
+
+      call random_number ( harvest = a(1:l,1:l) )
+      call random_number ( harvest = b(1:l,1:l) )
+
+      call cpu_time ( time1 )
+
+      do i = 1, l
+        do j = 1, l
+          c(i,j) = 0.0D+00
+          do k = 1, l
+            c(i,j) = c(i,j) + a(i,k) * b(k,j)
+          end do
+        end do
+      end do
+
+      call cpu_time ( time2 )
+
+      delta(l_log,rep) = time2 - time1
+
+      deallocate ( a )
+      deallocate ( b )
+      deallocate ( c )
+
+    end do
+
+  end do
+
+  write ( *, '(a)' ) ' '
+  write ( *, '(a)' ) '  Timing results using nested DO loops:'
+  write ( *, '(a)' ) ' '
+  write ( *, '(a)' ) '    Vector Size  Rep #1        Rep #2        Rep #3        ' &
+    // 'Rep #4        Rep #5'
+  write ( *, '(a)' ) ' '
+  do l_log = l_log_min, l_log_max - 1
+    l = 4**( l_log )
+    write ( *, '(i10,5f14.6)' ) l, delta(l_log,1:rep_num)
+  end do
+
+  write ( *, '(a)' ) ' '
+  write ( *, '(a)' ) '  Use the MATMUL routine for matrix multiplication.'
+
+  do rep = 1, rep_num
+
+    do l_log = l_log_min, l_log_max
+
+      l = 4**( l_log )
+      m = l
+      n = l
+
+      allocate ( a(1:l,1:l) )
+      allocate ( b(1:l,1:l) )
+      allocate ( c(1:l,1:l) )
+
+      call random_number ( harvest = a(1:l,1:l) )
+      call random_number ( harvest = b(1:l,1:l) )
+
+      call cpu_time ( time1 )
+
+      c = matmul ( a, b )
+
+      call cpu_time ( time2 )
+
+      delta(l_log,rep) = time2 - time1
+
+      deallocate ( a )
+      deallocate ( b )
+      deallocate ( c )
+
+    end do
+
+  end do
+
+  write ( *, '(a)' ) ' '
+  write ( *, '(a)' ) '  Timing results using MATMUL:'
+  write ( *, '(a)' ) ' '
+  write ( *, '(a)' ) '    Vector Size  Rep #1        Rep #2        Rep #3        ' &
+    // 'Rep #4        Rep #5'
+  write ( *, '(a)' ) ' '
+  do l_log = l_log_min, l_log_max
+    l = 4**( l_log )
+    write ( *, '(i10,5f14.6)' ) l, delta(l_log,1:rep_num)
+  end do
+
+  return
+end
+subroutine timestamp ( )
+
+!*****************************************************************************80
+!
+!! TIMESTAMP prints the current YMDHMS date as a time stamp.
+!
+!  Example:
+!
+!    May 31 2001   9:45:54.872 AM
+!
+!  Licensing:
+!
+!    This code is distributed under the GNU LGPL license.
+!
+!  Modified:
+!
+!    31 May 2001
+!
+!  Author:
+!
+!    John Burkardt
+!
+!  Parameters:
+!
+!    None
+!
+  implicit none
+
+  character ( len = 8 ) ampm
+  integer ( kind = 4 ) d
+  character ( len = 8 ) date
+  integer ( kind = 4 ) h
+  integer ( kind = 4 ) m
+  integer ( kind = 4 ) mm
+  character ( len = 9 ), parameter, dimension(12) :: month = (/ &
+    'January  ', 'February ', 'March    ', 'April    ', &
+    'May      ', 'June     ', 'July     ', 'August   ', &
+    'September', 'October  ', 'November ', 'December ' /)
+  integer ( kind = 4 ) n
+  integer ( kind = 4 ) s
+  character ( len = 10 ) time
+  integer ( kind = 4 ) values(8)
+  integer ( kind = 4 ) y
+  character ( len = 5 ) zone
+
+  call date_and_time ( date, time, zone, values )
+
+  y = values(1)
+  m = values(2)
+  d = values(3)
+  h = values(5)
+  n = values(6)
+  s = values(7)
+  mm = values(8)
+
+  if ( h < 12 ) then
+    ampm = 'AM'
+  else if ( h == 12 ) then
+    if ( n == 0 .and. s == 0 ) then
+      ampm = 'Noon'
+    else
+      ampm = 'PM'
+    end if
+  else
+    h = h - 12
+    if ( h < 12 ) then
+      ampm = 'PM'
+    else if ( h == 12 ) then
+      if ( n == 0 .and. s == 0 ) then
+        ampm = 'Midnight'
+      else
+        ampm = 'AM'
+      end if
+    end if
+  end if
+
+  write ( *, '(a,1x,i2,1x,i4,2x,i2,a1,i2.2,a1,i2.2,a1,i3.3,1x,a)' ) &
+    trim ( month(m) ), d, y, h, ':', n, ':', s, '.', mm, trim ( ampm )
+
+  return
+end


### PR DESCRIPTION
Now the output of test looks as it is shown below. Each test includes the total user time and the relative execution time compared with a reference. If LATTE_PERFORMANCE=yes a test is considered that fails if the relative execution time is larger than 10% of the pre-established values described in the file test/run_test.sh

Reference elapsed CPU time
==========================

   Testing for reference ... (13.62s,1.000) PASSED

Testing LATTE with new (latte.in) input files
=============================================

   Testing for single.point ... (1.27s,0.093) PASSED
   Testing for single.point.noelec ... (0.65s,0.048) PASSED
   Testing for single.point.rspace ... (0.69s,0.051) PASSED
   Testing for opt ... (71.71s,5.265) PASSED
   Testing for opt.cg ... (75.30s,5.529) PASSED
   Testing for opt_cons ... (71.63s,5.259) PASSED
   Testing for dorbitals ... (48.83s,3.585) PASSED
   Testing for tableread ... (12.43s,0.913) PASSED
   Testing for 0scf ... (8.78s,0.645) PASSED
   Testing for 2scf ... (7.68s,0.564) PASSED
   Testing for fullscf ... (11.66s,0.856) PASSED
   Testing for fullscf.etemp ... (11.24s,0.825) PASSED
   Testing for sp2 ... (6.95s,0.510) PASSED
   Testing for sp2.sparse ... (37.78s,2.774) PASSED
   Testing for fullscf.nvt ... (12.39s,0.910) PASSED
   Testing for fullscf.npt ... (12.44s,0.913) PASSED
   Testing for fullscf.vdw ... (11.54s,0.847) PASSED
   Testing for fullscf.spin ... (16.14s,1.185) PASSED
   Testing for fullscf.kon ... (30.04s,2.206) PASSED
   Testing for fullscf.rspace ... (3.72s,0.273) PASSED
   Testing for fittingoutput.dat ... (1.00s,0.073) PASSED

Testing LATTE with original input files
=======================================

   Testing for 0scf ... (8.14s,0.598) PASSED
   Testing for fullscf ... (13.64s,1.001) PASSED
   Testing for sp2 ... (7.32s,0.537) PASSED

End of run and test