### PR TITLE
Fixed wrtfreq bug for readmdcontroller

### DIFF
--- a/src/readmdcontroller.f90
+++ b/src/readmdcontroller.f90
@@ -80,6 +80,12 @@ SUBROUTINE READMDCONTROLLER
 
   READ(15,*) HD, WRTFREQ
 
+  IF ( WRTFREQ <= 0 ) THEN 
+    CALL ERRORS("latteparser_latte_mod","You cannot have WRTFREQ <= 0.& 
+                &Set this variable to a very high value to avoid frequent printing")
+  ENDIF
+
+
   !
   ! TOINITTEMP: Whether or not we are going to initialize velocities
   ! using a random number generator (sometimes during a restart we


### PR DESCRIPTION
Same as for latteparser. Latte will stop if WRTFREQ =< 0 